### PR TITLE
Add 'svg' to valid image extensions

### DIFF
--- a/src/lity.js
+++ b/src/lity.js
@@ -17,7 +17,7 @@
     var _html = $('html');
     var _instanceCount = 0;
 
-    var _imageRegexp = /\.(png|jpg|jpeg|gif|tiff|bmp)(\?\S*)?$/i;
+    var _imageRegexp = /\.(png|jpg|jpeg|gif|tiff|bmp|svg)(\?\S*)?$/i;
     var _youtubeRegex = /(youtube(-nocookie)?\.com|youtu\.be)\/(watch\?v=|v\/|u\/|embed\/?)?([\w-]{11})(.*)?/i;
     var _vimeoRegex =  /(vimeo(pro)?.com)\/(?:[^\d]+)?(\d+)\??(.*)?$/;
     var _googlemapsRegex = /((maps|www)\.)?google\.([^\/\?]+)\/?((maps\/?)?\?)(.*)/i;


### PR DESCRIPTION
Fixes #9 

Just tested it out in my project, and adding 'svg' to the image regex _is_ sufficient.