### PR TITLE
Add Zepto module  to required modules list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@ supports images, iframes and inline content out of the box.
 Minified and gzipped, its total footprint weights about 3kB.
 
 It requires [jQuery](https://jquery.com) or [Zepto](http://zeptojs.com)
-(with the [callbacks](https://github.com/madrobby/zepto/blob/master/src/callbacks.js),
-[deferred](https://github.com/madrobby/zepto/blob/master/src/deferred.js) and
-[data](https://github.com/madrobby/zepto/blob/master/src/data.js)
-modules).
+(with the [callbacks](https://github.com/madrobby/zepto/blob/master/src/callbacks.js), [data](https://github.com/madrobby/zepto/blob/master/src/data.js), [deferred](https://github.com/madrobby/zepto/blob/master/src/deferred.js) and [event](https://github.com/madrobby/zepto/blob/master/src/event.js) modules).
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ supports images, iframes and inline content out of the box.
 Minified and gzipped, its total footprint weights about 3kB.
 
 It requires [jQuery](https://jquery.com) or [Zepto](http://zeptojs.com)
-(with the [callbacks](https://github.com/madrobby/zepto/blob/master/src/callbacks.js), [data](https://github.com/madrobby/zepto/blob/master/src/data.js), [deferred](https://github.com/madrobby/zepto/blob/master/src/deferred.js) and [event](https://github.com/madrobby/zepto/blob/master/src/event.js) modules).
+(with the [callbacks](https://github.com/madrobby/zepto/blob/master/src/callbacks.js), 
+[data](https://github.com/madrobby/zepto/blob/master/src/data.js), 
+[deferred](https://github.com/madrobby/zepto/blob/master/src/deferred.js) and 
+[event](https://github.com/madrobby/zepto/blob/master/src/event.js) modules).
 
 Installation
 ------------


### PR DESCRIPTION
When creating a custom Zepto build with only Zepto core and the modules `callbacks`, `deferred` and `data`, lity.js throws the error 

> lity.js:647 Uncaught TypeError: $.proxy is not a function
    at lity.js:647
    at lity.js:12
    at lity.js:14

when used with Zepto.js instead of jQuery.

Which is because $proxy is defined in the Zepto module `event`. 