### PR TITLE
Compatibility with jQuery 3.5.0

### DIFF
--- a/dist/lity.js
+++ b/dist/lity.js
@@ -165,7 +165,7 @@
     }
 
     function error(msg) {
-        return $('<span class="lity-error"/>').append(msg);
+        return $('<span class="lity-error"></span>').append(msg);
     }
 
     function imageHandler(target, instance) {
@@ -207,7 +207,7 @@
             return false;
         }
 
-        placeholder = $('<i style="display:none !important"/>');
+        placeholder = $('<i style="display:none !important"></i>');
         hasHideClass = el.hasClass('lity-hide');
 
         instance

--- a/src/lity.js
+++ b/src/lity.js
@@ -162,7 +162,7 @@
     }
 
     function error(msg) {
-        return $('<span class="lity-error"/>').append(msg);
+        return $('<span class="lity-error"></span>').append(msg);
     }
 
     function imageHandler(target, instance) {
@@ -204,7 +204,7 @@
             return false;
         }
 
-        placeholder = $('<i style="display:none !important"/>');
+        placeholder = $('<i style="display:none !important"></i>');
         hasHideClass = el.hasClass('lity-hide');
 
         instance


### PR DESCRIPTION
Usages like `$('<div/>')` must be changed to `$('<div></div>')`

See the blog post:
https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/
and the upgrade guide for more details:
https://jquery.com/upgrade-guide/3.5/