### PR TITLE
Allow to close the box while loading if loading time too long

### DIFF
--- a/src/lity.js
+++ b/src/lity.js
@@ -440,7 +440,7 @@
         };
 
         self.close = function() {
-            if (!isReady || isClosed) {
+            if (isClosed) {
                 return;
             }
 
@@ -466,16 +466,17 @@
                 }
             }
 
-            content.trigger('lity:close', [self]);
+            var trigerable = (content ? content : element);
+            trigerable.trigger('lity:close', [self]);
 
             element
                 .removeClass('lity-opened')
                 .addClass('lity-closed')
             ;
 
-            transitionEnd(content.add(element))
+            transitionEnd(trigerable.add(element))
                 .always(function() {
-                    content.trigger('lity:remove', [self]);
+                    trigerable.trigger('lity:remove', [self]);
                     element.remove();
                     element = undefined;
                     deferred.resolve();
@@ -509,6 +510,9 @@
         ;
 
         function ready(result) {
+            if (isClosed) {
+                return;
+            }
             content = $(result)
                 .css('max-height', winHeight() + 'px')
             ;


### PR DESCRIPTION
When the loading time is too long (box trying to load an huge image on a slow network or slow ajax request whith a personal handler), the user is stuck in front of the dark loading box without any way to escape.

With the patch it is possible to close with the escape key as well as the close button while still loading. 
As a result the `lity:ready` is never fired (the seems to me better than faking a ready fire) and the `lity:close` is triggered on `element` instead of `content`.

When the content is finaly loaded, it is silently ignored.