### PR TITLE
Add an option that force the focus to be inside the lity box on tab key (fix a flaw)

### DIFF
--- a/src/lity.js
+++ b/src/lity.js
@@ -31,6 +31,7 @@
             inline: inlineHandler,
             iframe: iframeHandler
         },
+        forceFocusInside: false,
         template: '<div class="lity" role="dialog" aria-label="Dialog Window (Press escape to close)" tabindex="-1"><div class="lity-wrap" data-lity-close role="document"><div class="lity-loader" aria-hidden="true">Loading...</div><div class="lity-container"><div class="lity-content"></div><button class="lity-close" type="button" aria-label="Close (Press escape to close)" data-lity-close>&times;</button></div></div></div>'
     };
 
@@ -263,6 +264,10 @@
             focusableElements.get(focusableElements.length - 1).focus();
             e.preventDefault();
         } else if (!e.shiftKey && focusedIndex === focusableElements.length - 1) {
+            focusableElements.get(0).focus();
+            e.preventDefault();
+        }
+        if (focusedIndex === -1 && instance.options().forceFocusInside) {
             focusableElements.get(0).focus();
             e.preventDefault();
         }


### PR DESCRIPTION
It was possible indeed to escape the box (at least on FF) by pressing tab key several times : after going through all the focusable elements of the box, the focus goes on browser navigation buttons (previous page, address bar field) before re-entering the page on the first focusable element of the page, which is not in the lity box any more
As this is happening without a shift key the handleTabKey() doesn't fix it and then you have to go through all the page to reenter the box.

As I'm not sure if this is the expected behavior, I added an option to activate the hard forced focus in the box, but maybe this is not needed and could be the default behavior?