### PR TITLE
Removed .lity-wrap:before{margin-right: -0.25em}

### DIFF
--- a/dist/lity.css
+++ b/dist/lity.css
@@ -54,7 +54,6 @@
   display: inline-block;
   height: 100%;
   vertical-align: middle;
-  margin-right: -0.25em;
 }
 
 .lity-loader {


### PR DESCRIPTION
It was annoying and pointless to have a margin-right on .lity-wrap:before.